### PR TITLE
Flesh out annotation types

### DIFF
--- a/resources/annotation.d.ts
+++ b/resources/annotation.d.ts
@@ -1,23 +1,27 @@
-import { SpecificResource } from '@iiif/presentation-3';
-
 import { OmitProperties, OneOrMany } from '../utility';
 import { TechnicalProperties } from '../iiif/technical';
 import { DescriptiveProperties } from '../iiif/descriptive';
 import { LinkingProperties } from '../iiif/linking';
-import { ContentResource } from './content-resource';
+import { ContentResource, ContentResourceSelector } from './content-resource';
 import { RightsProperties } from '../iiif/rights';
 
 type AnnotationOmittedTechnical = '@id' | 'format' | 'height' | 'width' | 'viewingDirection' | 'navDate';
 type AnnotationOmittedLinking = 'startCanvas';
 
 type AnnotationStructural = {
-  motivation: string;
-  resource: ContentResource;
+  motivation: OneOrMany<string>;
+  resource: OneOrMany<ContentResource>;
   stylesheet?: {
     '@type': ['oa:CssStyle', 'cnt:ContentAsText'];
     chars: string;
   };
   on: OneOrMany<string | { '@id': string } | SpecificResource>; // @todo maybe need to expand this.
+};
+
+export declare type SpecificResource = {
+  '@type': 'oa:SpecificResource',
+  full: string | ContentResource,
+  selector: ContentResourceSelector,
 };
 
 /**

--- a/resources/content-resource.d.ts
+++ b/resources/content-resource.d.ts
@@ -10,7 +10,7 @@ type ContentResourceSelector =
       region: string;
     }
   | {
-      '@type': ['oa:SvgSelector', 'cnt:ContentAsText'];
+      '@type': ['oa:SvgSelector', 'cnt:ContentAsText'] | [ 'cnt:ContentAsText', 'oa:SvgSelector' ] | 'oa:SvgSelector';
       chars: string;
     }
   | {
@@ -23,7 +23,16 @@ type ContentResourceSelector =
       '@type': 'iiif:ImageApiSelector';
       region: string;
       rotation: string;
-    };
+    }
+  | {
+      '@type': 'oa:Choice';
+      default: ContentResourceSelector;
+      item: ContentResourceSelector | ContentResourceSelector[];
+    }
+  | {
+      '@type': 'oa:FragmentSelector';
+      value: string;
+    }
 
 type ImageResourceSegment = {
   '@id': string;

--- a/traversal.d.ts
+++ b/traversal.d.ts
@@ -29,7 +29,7 @@ export type TraversableEntityTypes =
   | 'sc:Collection'
   | 'sc:Manifest'
   | 'sc:Canvas'
-  | 'oa:AnnotationList'
+  | 'sc:AnnotationList'
   | 'oa:Annotation'
   | 'sc:Range'
   | 'sc:Layer'


### PR DESCRIPTION
- Use `SpecificResource` from OpenAnnotation, instead of WebAnnotation
- Allow single-string `oa:SvgSelector` `@type` for SVG selectors
- Add support for `oa:Choice`
- Add support for `oa:FragmentSelector`

Types are based on examples from these sources:
- [IIIF Presentation API 2.1 specification (`SpecificResource`)][1]
- [Annotations sourced from Mirador 2 (`Choice`, `SvgSelector`, `FragmentSelector`)][2]
- [Annotation fixtures by Régis Robineau (`Choice`, `SvgSelector`, `FragmentSelector`)][3]

[1]: https://iiif.io/api/presentation/2.1/#non-rectangular-segments
[2]: https://annotot-app.herokuapp.com/annotations?uri=https%3A%2F%2Fpurl.stanford.edu%2Fch264fq0568%2Fiiif%2Fcanvas%2Fch264fq0568_1&format=json
[3]: https://gist.github.com/regisrob/2aca29ddcbe52fdbd53080b7893320fb